### PR TITLE
Show merged playtime on parent Steam games

### DIFF
--- a/py_modules/statistics.py
+++ b/py_modules/statistics.py
@@ -159,10 +159,14 @@ class Statistics:
 
         parent_to_children: Dict[str, List[str]] = {}
         child_to_parent: Dict[str, str] = {}
+        parent_names: Dict[str, str] = {}
 
         for assoc in all_associations:
             parent_id = assoc["parent_game_id"]
             child_id = assoc["child_game_id"]
+            parent_name = assoc.get("parent_game_name")
+            parent_names[parent_id] = parent_name if parent_name else "Unknown Game"
+
             child_to_parent[child_id] = parent_id
             if parent_id not in parent_to_children:
                 parent_to_children[parent_id] = []
@@ -190,10 +194,32 @@ class Statistics:
             else:
                 result.append(info)
 
+        # Add parents that didn't have their own playtime
+        from py_modules.db.dao import PlaytimeInformation
+        for parent_id, children_ids in parent_to_children.items():
+            if parent_id not in games_by_id:
+                # Create a blank parent info to merge children into
+                game_name = parent_names.get(parent_id, "Unknown Game")
+                parent_info = PlaytimeInformation(
+                    game_id=parent_id,
+                    total_time=0.0,
+                    last_played_date="",
+                    game_name=game_name,
+                    aliases_id=None,
+                )
+                merged_info = self._merge_playtime_info(
+                    parent_info, children_ids, games_by_id
+                )
+                if merged_info.total_time > 0:
+                    result.append(merged_info)
+
         return result
 
     def _merge_playtime_info(
-        self, parent_info, children_ids: List[str], games_by_id: Dict[str, Any]
+        self,
+        parent_info,
+        children_ids: List[str],
+        games_by_id: Dict[str, Any],
     ):
         from py_modules.db.dao import PlaytimeInformation
 

--- a/py_modules/tests/association_manager_test.py
+++ b/py_modules/tests/association_manager_test.py
@@ -789,5 +789,174 @@ class TestDailyStatisticsForSpecificGame(AbstractDatabaseTest):
         self.assertNotIn("child_game", game_ids)
 
 
+class TestPlaytimeInformationWithAssociations(AbstractDatabaseTest):
+    """Test that playtime information applies game associations."""
+
+    dao: Dao
+    association_manager: AssociationManager
+
+    def setUp(self) -> None:
+        super().setUp()
+        DbMigration(db=self.database).migrate()
+        self.dao = Dao(db=self.database)
+        self.association_manager = AssociationManager(dao=self.dao)
+
+    def _create_game_with_session_on_date(
+        self,
+        game_id: str,
+        game_name: str,
+        session_date: datetime,
+        playtime_seconds: int = 3600,
+    ):
+        """Helper to create a game with a play session."""
+        self.dao.save_game_dict(game_id, game_name)
+        self.dao.save_play_time(
+            start=session_date,
+            time_s=playtime_seconds,
+            game_id=game_id,
+            source=None,
+        )
+
+    def test_fetch_playtime_information_merges_children_with_no_parent_playtime(self):
+        from py_modules.statistics import Statistics
+
+        # Parent has no playtime, just in game_dict
+        self.dao.save_game_dict("parent_game", "Parent Game")
+
+        # Child 1 played recently
+        self._create_game_with_session_on_date(
+            "child_1", "Child 1", datetime(2023, 1, 15, 10, 0), 1800
+        )
+        # Child 2 played even more recently
+        self._create_game_with_session_on_date(
+            "child_2", "Child 2", datetime(2023, 1, 16, 10, 0), 900
+        )
+        # Unrelated game
+        self._create_game_with_session_on_date(
+            "unrelated", "Unrelated Game", datetime(2023, 1, 10, 10, 0), 3600
+        )
+
+        self.dao.create_game_association("parent_game", "child_1")
+        self.dao.create_game_association("parent_game", "child_2")
+
+        statistics = Statistics(
+            dao=self.dao,
+            tracking_manager=None,
+            association_manager=self.association_manager,
+        )
+
+        result = statistics.fetch_playtime_information()
+
+        # Should have parent and unrelated game, children hidden
+        self.assertEqual(len(result), 2)
+
+        game_ids = [r["game"]["id"] for r in result]
+        self.assertIn("parent_game", game_ids)
+        self.assertIn("unrelated", game_ids)
+        self.assertNotIn("child_1", game_ids)
+        self.assertNotIn("child_2", game_ids)
+
+        parent_result = next(r for r in result if r["game"]["id"] == "parent_game")
+
+        # Child time is summed exactly once
+        self.assertEqual(parent_result["total_time"], 2700)
+
+        # Latest child date retained (as string)
+        self.assertEqual(parent_result["last_played_date"], "2023-01-16T10:00:00")
+
+        # Parent name retained
+        self.assertEqual(parent_result["game"]["name"], "Parent Game")
+
+        # Child IDs appear in aliases_id
+        aliases = parent_result["aliases_id"].split(",")
+        self.assertIn("child_1", aliases)
+        self.assertIn("child_2", aliases)
+
+    def test_fetch_playtime_information_handles_empty_parent_name(self):
+        from py_modules.statistics import Statistics
+
+        # Create parent with empty name, child with playtime
+        self.dao.save_game_dict("empty_name_parent", "")
+
+        # Give child playtime in the last two weeks
+        now = datetime.now()
+        self._create_game_with_session_on_date(
+            "child_3", "Child 3", now, 1800
+        )
+
+        self.dao.create_game_association("empty_name_parent", "child_3")
+
+        statistics = Statistics(
+            dao=self.dao,
+            tracking_manager=None,
+            association_manager=self.association_manager,
+        )
+
+        # Use last two weeks so the parent (no playtime) is NOT returned by the DAO,
+        # forcing the python code to synthesize it and use parent_names fallback.
+        result = statistics.get_statistics_for_last_two_weeks()
+
+        parent_result = next(r for r in result if r["game"]["id"] == "empty_name_parent")
+
+        # Parent name should fall back to "Unknown Game" instead of empty/null
+        self.assertEqual(parent_result["game"]["name"], "Unknown Game")
+
+    def test_get_statistics_for_last_two_weeks_merges_children(self):
+        from py_modules.statistics import Statistics
+        from py_modules.helpers import start_of_week
+        from datetime import timedelta
+
+        self.dao.save_game_dict("parent_game", "Parent Game")
+        self.dao.save_game_dict("unrelated", "Unrelated Game")
+
+        now = datetime.now()
+        start_current_week = start_of_week(now)
+        two_weeks_ago_start = start_current_week - timedelta(weeks=1)
+
+        inside_two_weeks = two_weeks_ago_start + timedelta(days=2)
+        outside_two_weeks = two_weeks_ago_start - timedelta(days=20)
+
+        # Child 1 played inside two weeks
+        self._create_game_with_session_on_date(
+            "child_1", "Child 1", inside_two_weeks, 1800
+        )
+        # Child 2 played outside two weeks
+        self._create_game_with_session_on_date(
+            "child_2", "Child 2", outside_two_weeks, 900
+        )
+        # Unrelated played inside two weeks
+        self._create_game_with_session_on_date(
+            "unrelated", "Unrelated Game", inside_two_weeks, 3600
+        )
+
+        self.dao.create_game_association("parent_game", "child_1")
+        self.dao.create_game_association("parent_game", "child_2")
+
+        statistics = Statistics(
+            dao=self.dao,
+            tracking_manager=None,
+            association_manager=self.association_manager,
+        )
+
+        result = statistics.get_statistics_for_last_two_weeks()
+
+        # Should have parent and unrelated game, child_2 is out of bounds for the DB query
+        # so it won't be returned by the DAO, hence won't be merged.
+        self.assertEqual(len(result), 2)
+
+        game_ids = [r["game"]["id"] for r in result]
+        self.assertIn("parent_game", game_ids)
+        self.assertIn("unrelated", game_ids)
+
+        parent_result = next(r for r in result if r["game"]["id"] == "parent_game")
+
+        # Child time is summed exactly once, only the 1800 from within two weeks
+        self.assertEqual(parent_result["total_time"], 1800)
+
+        aliases = parent_result["aliases_id"].split(",")
+        self.assertIn("child_1", aliases)
+        self.assertNotIn("child_2", aliases)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -38,6 +38,8 @@ export interface PlayTimeSettings {
 	coverScale: number;
 	selectedSortByOption: SortByKeys;
 	isEnabledDetectionOfGamesByFileChecksum: boolean;
+	/** Whether associated playtime may replace native Steam parent values */
+	isMergedPlaytimeEnabled: boolean;
 	/** When true, MonthView shows stacked bars per game; otherwise shows aggregated bars */
 	isStackedBarsPerGameEnabled: boolean;
 	/** Maximum number of games to display in PieView. -1 means show all */
@@ -63,7 +65,7 @@ export enum ChartStyle {
 
 const PLAY_TIME_SETTINGS_KEY = "decky-loader-SDH-Playtime";
 
-export const CURRENT_SETTINGS_VERSION = 1;
+export const CURRENT_SETTINGS_VERSION = 2;
 
 /** Current plugin version from package.json (injected at build time) */
 declare const __PLUGIN_VERSION__: string;
@@ -81,6 +83,7 @@ function createDefaultSettings(): PlayTimeSettings {
 		coverScale: 1,
 		selectedSortByOption: "mostPlayed",
 		isEnabledDetectionOfGamesByFileChecksum: false,
+		isMergedPlaytimeEnabled: false,
 		isStackedBarsPerGameEnabled: false,
 		pieViewGamesLimit: -1,
 		chartColorSwatch: "Vibrant",
@@ -100,6 +103,11 @@ const migrations: Record<number, (settings: UnknownRecord) => UnknownRecord> = {
 	0: (settings) => ({
 		...settings,
 		settingsVersion: 1,
+	}),
+	1: (settings) => ({
+		...settings,
+		settingsVersion: 2,
+		isMergedPlaytimeEnabled: settings.isMergedPlaytimeEnabled ?? false,
 	}),
 };
 
@@ -217,6 +225,9 @@ function normalizeSettings(value: unknown): PlayTimeSettings {
 		isEnabledDetectionOfGamesByFileChecksum:
 			toBoolean(merged.isEnabledDetectionOfGamesByFileChecksum) ??
 			defaults.isEnabledDetectionOfGamesByFileChecksum,
+		isMergedPlaytimeEnabled:
+			toBoolean(merged.isMergedPlaytimeEnabled) ??
+			defaults.isMergedPlaytimeEnabled,
 		isStackedBarsPerGameEnabled:
 			toBoolean(merged.isStackedBarsPerGameEnabled) ??
 			defaults.isStackedBarsPerGameEnabled,
@@ -263,6 +274,7 @@ function toStoredSettings(settings: PlayTimeSettings): UnknownRecord {
 		},
 		isEnabledDetectionOfGamesByFileChecksum:
 			+settings.isEnabledDetectionOfGamesByFileChecksum,
+		isMergedPlaytimeEnabled: +settings.isMergedPlaytimeEnabled,
 		isStackedBarsPerGameEnabled: +settings.isStackedBarsPerGameEnabled,
 		showKofiInQAM: +settings.showKofiInQAM,
 	};
@@ -270,10 +282,14 @@ function toStoredSettings(settings: PlayTimeSettings): UnknownRecord {
 
 export class Settings {
 	private readonly initialization: Promise<void>;
+	private currentSettings = createDefaultSettings();
+	private mergedPlaytimeSubscribers = new Set<(enabled: boolean) => void>();
 
 	constructor() {
 		this.initialization = this.normalizeStoredSettings()
-			.then(() => undefined)
+			.then((settings) => {
+				this.currentSettings = settings;
+			})
 			.catch((error: unknown) => {
 				logger.error("Unable to normalize settings", error);
 			});
@@ -339,14 +355,39 @@ export class Settings {
 		});
 	}
 
+	/** Synchronous access is required by Steam's render-time patch callbacks. */
+	isMergedPlaytimeEnabled(): boolean {
+		return this.currentSettings.isMergedPlaytimeEnabled;
+	}
+
+	/** Lets Steam overview patches react without requiring a plugin reload. */
+	subscribeMergedPlaytimeEnabled(
+		callback: (enabled: boolean) => void,
+	): () => void {
+		this.mergedPlaytimeSubscribers.add(callback);
+
+		return () => this.mergedPlaytimeSubscribers.delete(callback);
+	}
+
 	async save(data: PlayTimeSettings): Promise<void> {
 		await this.initialization;
 
 		const normalized = normalizeSettings(data);
+		const mergedPlaytimeChanged =
+			this.currentSettings.isMergedPlaytimeEnabled !==
+			normalized.isMergedPlaytimeEnabled;
 
 		await SteamClient.Storage.SetObject(
 			PLAY_TIME_SETTINGS_KEY,
 			toStoredSettings(normalized),
 		);
+
+		this.currentSettings = normalized;
+
+		if (mergedPlaytimeChanged) {
+			for (const subscriber of this.mergedPlaytimeSubscribers) {
+				subscriber(normalized.isMergedPlaytimeEnabled);
+			}
+		}
 	}
 }

--- a/src/cachables.ts
+++ b/src/cachables.ts
@@ -2,22 +2,35 @@ import { Backend } from "./app/backend";
 import { UpdatableCache, UpdateOnEventCache } from "./app/cache";
 import type { EventBus } from "./app/system";
 
-type PlayTimeEntry = { time: number; lastDate: number };
+type PlayTimeEntry = { time: number; lastDate: number; isMerged?: boolean };
 
-function buildPlayTimeMap(
+export function buildPlayTimeMap(
 	records: Array<{
 		game: { id: string };
 		totalTime: number;
 		lastPlayedDate: string;
+		aliasesId?: string;
 	}>,
 ): Map<string, PlayTimeEntry> {
 	const map = new Map<string, PlayTimeEntry>();
 
 	for (const record of records) {
-		map.set(record.game.id, {
+		const entry: PlayTimeEntry = {
 			time: record.totalTime,
 			lastDate: new Date(record.lastPlayedDate).getTime() / 1000,
-		});
+			isMerged: !!record.aliasesId,
+		};
+
+		map.set(record.game.id, entry);
+
+		if (record.aliasesId) {
+			const aliases = record.aliasesId.split(",");
+			for (const alias of aliases) {
+				if (alias.trim()) {
+					map.set(alias.trim(), entry);
+				}
+			}
+		}
 	}
 
 	return map;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -422,9 +422,20 @@ function createMountables(
 		},
 	});
 
-	mounts.push(patchAppPage(cachedPlayTimes));
 	mounts.push(
-		new SteamPlayTimePatches(cachedPlayTimes, cachedLastTwoWeeksPlayTimes),
+		patchAppPage(
+			cachedPlayTimes,
+			() => settings.isMergedPlaytimeEnabled(),
+			(callback) => settings.subscribeMergedPlaytimeEnabled(callback),
+		),
+	);
+	mounts.push(
+		new SteamPlayTimePatches(
+			cachedPlayTimes,
+			cachedLastTwoWeeksPlayTimes,
+			() => settings.isMergedPlaytimeEnabled(),
+			(callback) => settings.subscribeMergedPlaytimeEnabled(callback),
+		),
 	);
 
 	return mounts;

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -8,6 +8,7 @@ import {
 	PanelSectionRow,
 	SidebarNavigation,
 	type SidebarNavigationPage,
+	ToggleField,
 } from "@decky/ui";
 import { $gameChecksumsLoadingState } from "@src/stores/games";
 import { useEffect, useRef, useState } from "react";
@@ -433,8 +434,33 @@ const GeneralSettings = () => {
 };
 
 const TimeManipulation = () => {
+	const { currentSettings, settings, setCurrentSettings } = useLocator();
+
+	const setMergedPlaytimeEnabled = async (enabled: boolean) => {
+		const updated = {
+			...currentSettings,
+			isMergedPlaytimeEnabled: enabled,
+		};
+
+		try {
+			await settings.save(updated);
+			setCurrentSettings(updated);
+		} catch (error) {
+			logger.error("Unable to save merged playtime setting", error);
+		}
+	};
+
 	return (
 		<div>
+			<PanelSection title="Merged playtime">
+				<ToggleField
+					label="Show merged playtime on parent games"
+					description="Replace a parent game's Steam playtime with the combined playtime from its associated and aliased games."
+					checked={currentSettings.isMergedPlaytimeEnabled}
+					onChange={setMergedPlaytimeEnabled}
+				/>
+			</PanelSection>
+
 			<PanelSection title="Change overall play time">
 				<PanelSectionRow>
 					<ButtonItem onClick={() => navigateToPage(MANUALLY_ADJUST_TIME)}>
@@ -543,7 +569,7 @@ const AboutSection = () => {
 						"Blake Polzer",
 						"Reusable-Box",
 						"retroshelf.org",
-						"burritobob"
+						"burritobob",
 					].map((name, i, arr) => (
 						<span key={name}>
 							<span style={{ color: "#ff9966", fontWeight: 500 }}>{name}</span>
@@ -663,7 +689,7 @@ export function SettingsPage() {
 			),
 		},
 		{
-			title: "Time manipulation",
+			title: "Time Management",
 			icon: <MdModeEdit />,
 			content: (
 				<Tab>

--- a/src/steam/ui/routePatches.ts
+++ b/src/steam/ui/routePatches.ts
@@ -1,20 +1,19 @@
-import { type RoutePatch, routerHook } from "@decky/api";
+import { routerHook } from "@decky/api";
 import { afterPatch } from "@decky/ui";
 import type { Cache } from "@src/app/cache";
 import type { Mountable } from "@src/app/system";
 import { APP_TYPE } from "@src/constants";
 import type { ReactElement } from "react";
 
-function routePatch(path: string, patch: RoutePatch): Mountable {
-	return {
-		mount() {
-			routerHook.addPatch(path, patch);
-		},
-		unMount() {
-			routerHook.removePatch(path, patch);
-		},
-	};
-}
+type SubscribeMergedPlaytimeEnabled = (
+	callback: (enabled: boolean) => void,
+) => () => void;
+
+type NativeDetailSnapshot = {
+	details: AppDetails;
+	nativeTime: number;
+	lastMergedTime: number | null;
+};
 
 export function patchAppPage(
 	timeCache: Cache<
@@ -23,44 +22,146 @@ export function patchAppPage(
 			{
 				time: number;
 				lastDate: number;
+				isMerged?: boolean;
 			}
 		>
 	>,
+	isMergedPlaytimeEnabled: () => boolean = () => false,
+	subscribeMergedPlaytimeEnabled: SubscribeMergedPlaytimeEnabled | null = null,
 ): Mountable {
-	return routePatch(
-		"/library/app/:appid",
-		(props: { path: string; children: ReactElement }) => {
-			afterPatch(props.children.props, "renderFunc", (_, ret1) => {
-				const overview: AppOverview = ret1?.props?.children?.props?.overview;
+	const nativeDetailSnapshots = new Map<number, NativeDetailSnapshot>();
+	let unsubscribeMergedPlaytimeEnabled: (() => void) | null = null;
 
-				if (!overview) return ret1;
+	const mergedTimeFor = (appId: number): number | null => {
+		const record = timeCache.get()?.get(appId.toString());
+		if (!record?.isMerged || !timeCache.isReady()) {
+			return null;
+		}
 
-				const details: AppDetails = ret1?.props?.children?.props?.details;
+		return +(record.time / 60.0).toFixed(1);
+	};
 
-				if (!details) return ret1;
+	const restoreNativeDetails = (clear: boolean) => {
+		for (const [appId, snapshot] of nativeDetailSnapshots) {
+			snapshot.details.nPlaytimeForever = snapshot.nativeTime;
+			snapshot.lastMergedTime = null;
 
-				const app_id: number = overview?.appid;
+			if (clear) {
+				nativeDetailSnapshots.delete(appId);
+			}
+		}
+	};
 
-				if (!app_id) return ret1;
+	const applyMergedDetails = () => {
+		for (const [appId, snapshot] of nativeDetailSnapshots) {
+			const mergedTime = mergedTimeFor(appId);
+			if (mergedTime === null) {
+				snapshot.details.nPlaytimeForever = snapshot.nativeTime;
+				nativeDetailSnapshots.delete(appId);
+				continue;
+			}
 
-				// just getting value - it fixes blinking issue
-				details.nPlaytimeForever;
+			if (
+				snapshot.lastMergedTime === null ||
+				snapshot.details.nPlaytimeForever !== snapshot.lastMergedTime
+			) {
+				snapshot.nativeTime = snapshot.details.nPlaytimeForever;
+			}
 
-				if (overview.app_type === APP_TYPE.THIRD_PARTY) {
-					if (details && timeCache.isReady()) {
-						const time = timeCache.get()?.get(app_id.toString())?.time || 0;
+			snapshot.details.nPlaytimeForever = mergedTime;
+			snapshot.lastMergedTime = mergedTime;
+		}
+	};
 
-						details.nPlaytimeForever = +(time / 60.0).toFixed(1);
+	const patch = (props: { path: string; children: ReactElement }) => {
+		afterPatch(props.children.props, "renderFunc", (_, ret1) => {
+			const overview: AppOverview = ret1?.props?.children?.props?.overview;
+
+			if (!overview) return ret1;
+
+			const details: AppDetails = ret1?.props?.children?.props?.details;
+
+			if (!details) return ret1;
+
+			const app_id: number = overview?.appid;
+
+			if (!app_id) return ret1;
+
+			// just getting value - it fixes blinking issue
+			details.nPlaytimeForever;
+
+			if (overview.app_type === APP_TYPE.THIRD_PARTY) {
+				if (timeCache.isReady()) {
+					const time = timeCache.get()?.get(app_id.toString())?.time || 0;
+					details.nPlaytimeForever = +(time / 60.0).toFixed(1);
+				}
+			} else {
+				const mergedTime = mergedTimeFor(app_id);
+				let snapshot = nativeDetailSnapshots.get(app_id);
+
+				if (mergedTime === null) {
+					if (snapshot?.details === details) {
+						details.nPlaytimeForever = snapshot.nativeTime;
+						nativeDetailSnapshots.delete(app_id);
+					}
+				} else {
+					if (snapshot?.details !== details) {
+						snapshot = {
+							details,
+							nativeTime: details.nPlaytimeForever,
+							lastMergedTime: null,
+						};
+						nativeDetailSnapshots.set(app_id, snapshot);
+					}
+
+					if (isMergedPlaytimeEnabled()) {
+						if (
+							snapshot.lastMergedTime === null ||
+							details.nPlaytimeForever !== snapshot.lastMergedTime
+						) {
+							snapshot.nativeTime = details.nPlaytimeForever;
+						}
+
+						details.nPlaytimeForever = mergedTime;
+						snapshot.lastMergedTime = mergedTime;
+					} else {
+						if (snapshot.lastMergedTime === null) {
+							snapshot.nativeTime = details.nPlaytimeForever;
+						} else {
+							details.nPlaytimeForever = snapshot.nativeTime;
+							snapshot.lastMergedTime = null;
+						}
 					}
 				}
+			}
 
-				// just getting value - it fixes blinking issue
-				details.nPlaytimeForever;
+			// just getting value - it fixes blinking issue
+			details.nPlaytimeForever;
 
-				return ret1;
-			});
+			return ret1;
+		});
 
-			return props;
+		return props;
+	};
+
+	return {
+		mount() {
+			routerHook.addPatch("/library/app/:appid", patch);
+			unsubscribeMergedPlaytimeEnabled =
+				subscribeMergedPlaytimeEnabled?.((enabled) => {
+					if (enabled) {
+						applyMergedDetails();
+						return;
+					}
+
+					restoreNativeDetails(false);
+				}) ?? null;
 		},
-	);
+		unMount() {
+			unsubscribeMergedPlaytimeEnabled?.();
+			unsubscribeMergedPlaytimeEnabled = null;
+			restoreNativeDetails(true);
+			routerHook.removePatch("/library/app/:appid", patch);
+		},
+	};
 }

--- a/src/steam/ui/steamPlayTimePatches.ts
+++ b/src/steam/ui/steamPlayTimePatches.ts
@@ -9,8 +9,22 @@ type PlayTimeInformation = Map<
 	{
 		time: number;
 		lastDate: number;
+		isMerged?: boolean;
 	}
 >;
+
+type NativeOverviewSnapshot = Pick<
+	AppOverview,
+	| "minutes_playtime_forever"
+	| "minutes_playtime_last_two_weeks"
+	| "rt_last_time_locally_played"
+	| "rt_last_time_played"
+	| "rt_last_time_played_or_installed"
+>;
+
+type SubscribeMergedPlaytimeEnabled = (
+	callback: (enabled: boolean) => void,
+) => () => void;
 
 export class SteamPlayTimePatches implements Mountable {
 	private cachedOverallTime: Cache<PlayTimeInformation>;
@@ -19,17 +33,32 @@ export class SteamPlayTimePatches implements Mountable {
 	private latestLastTwoWeeksTimes: PlayTimeInformation | null = null;
 	private unsubscribeOverallTime: (() => void) | null = null;
 	private unsubscribeLastTwoWeeksTimes: (() => void) | null = null;
+	private unsubscribeMergedPlaytimeEnabled: (() => void) | null = null;
+	private isMergedPlaytimeEnabled: () => boolean;
+	private subscribeMergedPlaytimeEnabled: SubscribeMergedPlaytimeEnabled | null;
+	private nativeOverviewSnapshots = new Map<
+		number,
+		{ overview: AppOverview; values: NativeOverviewSnapshot }
+	>();
 
 	constructor(
 		cachedOverallTime: Cache<PlayTimeInformation>,
 		cachedLastTwoWeeksTimes: Cache<PlayTimeInformation>,
+		isMergedPlaytimeEnabled: () => boolean = () => false,
+		subscribeMergedPlaytimeEnabled: SubscribeMergedPlaytimeEnabled | null = null,
 	) {
 		this.cachedOverallTime = cachedOverallTime;
 		this.cachedLastTwoWeeksTimes = cachedLastTwoWeeksTimes;
+		this.isMergedPlaytimeEnabled = isMergedPlaytimeEnabled;
+		this.subscribeMergedPlaytimeEnabled = subscribeMergedPlaytimeEnabled;
 	}
 
 	public mount() {
 		this.unsubscribeFromCaches();
+		this.unsubscribeFromSettings();
+		this.RestoreOnAppOverviewChange();
+		this.RestoreAppStoreMapAppsSet();
+		this.restoreNativeMergedOverviews();
 		this.ReplaceAppInfoStoreOnAppOverviewChange();
 		this.ReplaceAppStoreMapAppsSet();
 
@@ -45,12 +74,31 @@ export class SteamPlayTimePatches implements Mountable {
 				this.patchOverviewsFromCaches();
 			},
 		);
+		this.unsubscribeMergedPlaytimeEnabled =
+			this.subscribeMergedPlaytimeEnabled?.((enabled) => {
+				if (enabled) {
+					this.patchOverviewsFromCaches();
+					return;
+				}
+
+				this.restoreNativeMergedOverviews();
+			}) ?? null;
 	}
 
 	private patchOverviewsFromCaches() {
 		if (!this.latestOverallTimes || !this.latestLastTwoWeeksTimes) {
 			return;
 		}
+
+		const mergedNativeAppIds = new Set<number>();
+		if (this.isMergedPlaytimeEnabled()) {
+			for (const [appId, record] of this.latestOverallTimes) {
+				if (record.isMerged) {
+					mergedNativeAppIds.add(Number.parseInt(appId, 10));
+				}
+			}
+		}
+		this.restoreNativeMergedOverviews(mergedNativeAppIds);
 
 		const changedApps = [];
 
@@ -59,7 +107,7 @@ export class SteamPlayTimePatches implements Mountable {
 				Number.parseInt(appId, 10),
 			);
 
-			if (appOverview?.app_type === APP_TYPE.THIRD_PARTY) {
+			if (this.isEligibleForPatch(appOverview)) {
 				this.patchOverviewWithValues(
 					appOverview,
 					time.time,
@@ -80,8 +128,10 @@ export class SteamPlayTimePatches implements Mountable {
 
 	public unMount() {
 		this.unsubscribeFromCaches();
+		this.unsubscribeFromSettings();
 		this.RestoreOnAppOverviewChange();
 		this.RestoreAppStoreMapAppsSet();
+		this.restoreNativeMergedOverviews();
 	}
 
 	private unsubscribeFromCaches() {
@@ -91,6 +141,28 @@ export class SteamPlayTimePatches implements Mountable {
 		this.unsubscribeLastTwoWeeksTimes = null;
 		this.latestOverallTimes = null;
 		this.latestLastTwoWeeksTimes = null;
+	}
+
+	private unsubscribeFromSettings() {
+		this.unsubscribeMergedPlaytimeEnabled?.();
+		this.unsubscribeMergedPlaytimeEnabled = null;
+	}
+
+	private restoreNativeMergedOverviews(keepPatched = new Set<number>()) {
+		for (const [appId, snapshot] of this.nativeOverviewSnapshots) {
+			if (keepPatched.has(appId)) {
+				continue;
+			}
+
+			if (appStore.GetAppOverviewByAppID(appId) !== snapshot.overview) {
+				this.nativeOverviewSnapshots.delete(appId);
+				continue;
+			}
+
+			Object.assign(snapshot.overview, snapshot.values);
+			appStore.m_mapApps.set(appId, snapshot.overview);
+			this.nativeOverviewSnapshots.delete(appId);
+		}
 	}
 
 	// here we patch AppInfoStore OnAppOverviewChange method so we can prepare changed app overviews for the next part of the patch (AppOverview.InitFromProto)
@@ -185,12 +257,14 @@ export class SteamPlayTimePatches implements Mountable {
 		for (const appId of appIds) {
 			const appOverview = appStore.GetAppOverviewByAppID(appId);
 
-			if (appOverview?.app_type === APP_TYPE.THIRD_PARTY) {
+			if (this.isEligibleForPatch(appOverview)) {
 				appOverview.OriginalInitFromProto = appOverview.InitFromProto;
 
 				appOverview.InitFromProto = (proto: unknown) => {
 					appOverview.OriginalInitFromProto(proto);
 
+					// Capture the newly refreshed Steam values before applying merged time.
+					this.nativeOverviewSnapshots.delete(appOverview.appid);
 					this.patchAppOverviewFromCache(appOverview);
 
 					appOverview.InitFromProto = appOverview.OriginalInitFromProto;
@@ -209,7 +283,7 @@ export class SteamPlayTimePatches implements Mountable {
 
 	private patchAppOverviewFromCache(appOverview: AppOverview): AppOverview {
 		if (
-			appOverview?.app_type === APP_TYPE.THIRD_PARTY &&
+			this.isEligibleForPatch(appOverview) &&
 			this.cachedOverallTime.isReady() &&
 			this.cachedLastTwoWeeksTimes.isReady()
 		) {
@@ -240,7 +314,11 @@ export class SteamPlayTimePatches implements Mountable {
 		lastTwoWeeksTime: number,
 		lastPlayedDate: number,
 	): AppOverview {
-		if (appOverview?.app_type === APP_TYPE.THIRD_PARTY) {
+		if (this.isEligibleForPatch(appOverview)) {
+			if (appOverview.app_type !== APP_TYPE.THIRD_PARTY) {
+				this.rememberNativeOverview(appOverview);
+			}
+
 			appOverview.minutes_playtime_forever = (overallTime / 60.0).toFixed(1);
 			appOverview.minutes_playtime_last_two_weeks = Number.parseFloat(
 				(lastTwoWeeksTime / 60.0).toFixed(1),
@@ -251,5 +329,40 @@ export class SteamPlayTimePatches implements Mountable {
 		}
 
 		return appOverview;
+	}
+
+	private rememberNativeOverview(appOverview: AppOverview) {
+		const existing = this.nativeOverviewSnapshots.get(appOverview.appid);
+		if (existing?.overview === appOverview) {
+			return;
+		}
+
+		// Retain Steam's values so disabling the feature is immediately reversible.
+		this.nativeOverviewSnapshots.set(appOverview.appid, {
+			overview: appOverview,
+			values: {
+				minutes_playtime_forever: appOverview.minutes_playtime_forever,
+				minutes_playtime_last_two_weeks:
+					appOverview.minutes_playtime_last_two_weeks,
+				rt_last_time_locally_played: appOverview.rt_last_time_locally_played,
+				rt_last_time_played: appOverview.rt_last_time_played,
+				rt_last_time_played_or_installed:
+					appOverview.rt_last_time_played_or_installed,
+			},
+		});
+	}
+
+	private isEligibleForPatch(
+		appOverview: AppOverview | null | undefined,
+	): boolean {
+		if (!appOverview) {
+			return false;
+		}
+		// Third-party patching predates merged playtime and stays independently active.
+		return (
+			appOverview.app_type === APP_TYPE.THIRD_PARTY ||
+			(this.isMergedPlaytimeEnabled() &&
+				!!this.cachedOverallTime.get()?.get(`${appOverview.appid}`)?.isMerged)
+		);
 	}
 }

--- a/src/test/cachables.spec.ts
+++ b/src/test/cachables.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("@decky/api", () => ({
+	call: async () => undefined,
+	toaster: { toast: () => {} },
+	routerHook: { addPatch: () => {}, removePatch: () => {} },
+}));
+
+const { buildPlayTimeMap } = await import("../cachables");
+
+describe("buildPlayTimeMap", () => {
+	it("maps unmerged record to its own game ID with falsey isMerged", () => {
+		const records = [
+			{
+				game: { id: "game1" },
+				totalTime: 3600,
+				lastPlayedDate: "2023-01-01T12:00:00Z",
+			},
+		];
+
+		const map = buildPlayTimeMap(records);
+		expect(map.size).toBe(1);
+
+		const entry = map.get("game1");
+		expect(entry).toBeDefined();
+		expect(entry?.time).toBe(3600);
+		expect(entry?.isMerged).toBeFalse();
+	});
+
+	it("maps a record with aliasesId to parent ID and every trimmed, non-empty alias ID", () => {
+		const records = [
+			{
+				game: { id: "parent_game" },
+				totalTime: 7200,
+				lastPlayedDate: "2023-01-01T12:00:00Z",
+				aliasesId: "child1, child2 ,child3",
+			},
+		];
+
+		const map = buildPlayTimeMap(records);
+
+		// parent + 3 children = 4 entries, pointing to the SAME object.
+		expect(map.size).toBe(4);
+
+		const parentEntry = map.get("parent_game");
+		expect(parentEntry?.isMerged).toBeTrue();
+		expect(parentEntry?.time).toBe(7200);
+
+		expect(map.get("child1")).toBe(parentEntry);
+		expect(map.get("child2")).toBe(parentEntry);
+		expect(map.get("child3")).toBe(parentEntry);
+	});
+
+	it("covers whitespace and empty alias tokens so malformed separators do not create empty cache keys", () => {
+		const records = [
+			{
+				game: { id: "parent_game" },
+				totalTime: 7200,
+				lastPlayedDate: "2023-01-01T12:00:00Z",
+				aliasesId: "child1,, , child2",
+			},
+		];
+
+		const map = buildPlayTimeMap(records);
+
+		expect(map.has("")).toBeFalse();
+		expect(map.has(" ")).toBeFalse();
+
+		// parent + 2 children = 3 entries
+		expect(map.size).toBe(3);
+		expect(map.has("parent_game")).toBeTrue();
+		expect(map.has("child1")).toBeTrue();
+		expect(map.has("child2")).toBeTrue();
+	});
+});

--- a/src/test/games.spec.ts
+++ b/src/test/games.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 mock.module("@decky/api", () => ({
 	call: async () => undefined,
 	toaster: { toast: () => {} },
+	routerHook: { addPatch: () => {}, removePatch: () => {} },
 }));
 
 const { Backend } = await import("@src/app/backend");

--- a/src/test/routePatches.spec.ts
+++ b/src/test/routePatches.spec.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Cache } from "@src/app/cache";
+
+type PlayTimeInformation = Map<
+	string,
+	{
+		time: number;
+		lastDate: number;
+		isMerged?: boolean;
+	}
+>;
+
+class FakeCache implements Cache<PlayTimeInformation> {
+	public data: PlayTimeInformation | null = null;
+	public isReady(): boolean {
+		return this.data !== null;
+	}
+	public get(): PlayTimeInformation | null {
+		return this.data;
+	}
+	public subscribe() {
+		return () => {};
+	}
+}
+
+type Details = { nPlaytimeForever: number };
+type Overview = { appid: number; app_type: number };
+type RenderResult = {
+	props: {
+		children: {
+			props: {
+				overview: Overview;
+				details: Details;
+			};
+		};
+	};
+};
+type RenderFunc = () => RenderResult;
+type RouteProps = { children: { props: { renderFunc: RenderFunc } } };
+
+let patchCallback: ((props: RouteProps) => void) | undefined;
+
+mock.module("@decky/api", () => ({
+	routerHook: {
+		addPatch: (_path: string, patch: (props: RouteProps) => void) => {
+			patchCallback = patch;
+		},
+		removePatch: () => {},
+	},
+	call: async () => undefined,
+	toaster: { toast: () => {} },
+}));
+
+mock.module("@decky/ui", () => ({
+	afterPatch: (
+		obj: Record<string, (...args: unknown[]) => unknown>,
+		funcName: string,
+		patch: (args: unknown[], ret: unknown) => unknown,
+	) => {
+		const original = obj[funcName];
+		obj[funcName] = (...args: unknown[]) => {
+			const ret = original ? original(...args) : undefined;
+			return patch(args, ret);
+		};
+	},
+}));
+
+const { patchAppPage } = await import("@src/steam/ui/routePatches");
+
+describe("routePatches", () => {
+	let timeCache: FakeCache;
+
+	beforeEach(() => {
+		timeCache = new FakeCache();
+		patchCallback = undefined;
+	});
+
+	test("native app with isMerged receives the merged playtime", () => {
+		const mountable = patchAppPage(timeCache, () => true);
+		mountable.mount();
+
+		timeCache.data = new Map([
+			[
+				"123",
+				{
+					time: 600,
+					lastDate: 5000,
+					isMerged: true,
+				},
+			],
+		]);
+
+		const details = { nPlaytimeForever: 5.0 };
+		const overview = { appid: 123, app_type: 1 }; // Not THIRD_PARTY
+
+		const props: RouteProps = {
+			children: {
+				props: {
+					renderFunc: () => ({
+						props: {
+							children: {
+								props: {
+									overview,
+									details,
+								},
+							},
+						},
+					}),
+				},
+			},
+		};
+
+		expect(patchCallback).toBeDefined();
+		if (patchCallback) {
+			patchCallback(props);
+		}
+
+		props.children.props.renderFunc();
+
+		expect(details.nPlaytimeForever).toBe(10.0); // 600 / 60
+	});
+
+	test("disabled merged playtime preserves native app values", () => {
+		const mountable = patchAppPage(timeCache, () => false);
+		mountable.mount();
+
+		timeCache.data = new Map([
+			[
+				"123",
+				{
+					time: 600,
+					lastDate: 5000,
+					isMerged: true,
+				},
+			],
+		]);
+
+		const details = { nPlaytimeForever: 5.0 };
+		const overview = { appid: 123, app_type: 1 };
+		const props: RouteProps = {
+			children: {
+				props: {
+					renderFunc: () => ({
+						props: {
+							children: { props: { overview, details } },
+						},
+					}),
+				},
+			},
+		};
+
+		expect(patchCallback).toBeDefined();
+		patchCallback?.(props);
+		props.children.props.renderFunc();
+
+		expect(details.nPlaytimeForever).toBe(5.0);
+	});
+
+	test("non-merged native app remains unchanged", () => {
+		const mountable = patchAppPage(timeCache);
+		mountable.mount();
+
+		timeCache.data = new Map([
+			[
+				"123",
+				{
+					time: 600,
+					lastDate: 5000,
+				},
+			],
+		]);
+
+		const details = { nPlaytimeForever: 5.0 };
+		const overview = { appid: 123, app_type: 1 }; // Not THIRD_PARTY
+
+		const props: RouteProps = {
+			children: {
+				props: {
+					renderFunc: () => ({
+						props: {
+							children: {
+								props: {
+									overview,
+									details,
+								},
+							},
+						},
+					}),
+				},
+			},
+		};
+
+		expect(patchCallback).toBeDefined();
+		if (patchCallback) {
+			patchCallback(props);
+		}
+
+		props.children.props.renderFunc();
+
+		expect(details.nPlaytimeForever).toBe(5.0); // Untouched
+	});
+
+	test("setting changes immediately patch and restore loaded app details", () => {
+		let enabled = false;
+		const settingSubscribers: Array<(enabled: boolean) => void> = [];
+		const mountable = patchAppPage(
+			timeCache,
+			() => enabled,
+			(callback) => {
+				settingSubscribers.push(callback);
+				return () => {
+					settingSubscribers.splice(0);
+				};
+			},
+		);
+		mountable.mount();
+		timeCache.data = new Map([
+			["123", { time: 600, lastDate: 5000, isMerged: true }],
+		]);
+		const details = { nPlaytimeForever: 5.0 };
+		const overview = { appid: 123, app_type: 1 };
+		const props: RouteProps = {
+			children: {
+				props: {
+					renderFunc: () => ({
+						props: {
+							children: { props: { overview, details } },
+						},
+					}),
+				},
+			},
+		};
+		patchCallback?.(props);
+		props.children.props.renderFunc();
+
+		enabled = true;
+		settingSubscribers[0](true);
+		expect(details.nPlaytimeForever).toBe(10.0);
+
+		enabled = false;
+		settingSubscribers[0](false);
+		expect(details.nPlaytimeForever).toBe(5.0);
+
+		details.nPlaytimeForever = 7.0;
+		props.children.props.renderFunc();
+		expect(details.nPlaytimeForever).toBe(7.0);
+
+		enabled = true;
+		settingSubscribers[0](true);
+		expect(details.nPlaytimeForever).toBe(10.0);
+		enabled = false;
+		settingSubscribers[0](false);
+		expect(details.nPlaytimeForever).toBe(7.0);
+
+		mountable.unMount();
+		expect(settingSubscribers).toHaveLength(0);
+	});
+});

--- a/src/test/settings.spec.ts
+++ b/src/test/settings.spec.ts
@@ -57,6 +57,7 @@ describe("Settings", () => {
 			coverScale: "1",
 			displayTime: { showTimeInHours: 1, showSeconds: 0 },
 			isEnabledDetectionOfGamesByFileChecksum: 0,
+			isMergedPlaytimeEnabled: 0,
 			isStackedBarsPerGameEnabled: 0,
 			showKofiInQAM: 1,
 		});
@@ -70,6 +71,7 @@ describe("Settings", () => {
 			coverScale: "0.5",
 			selectedSortByOption: "name",
 			isEnabledDetectionOfGamesByFileChecksum: "true",
+			isMergedPlaytimeEnabled: "true",
 			isStackedBarsPerGameEnabled: 1,
 			pieViewGamesLimit: "50",
 			chartColorSwatch: "DarkMuted",
@@ -90,6 +92,7 @@ describe("Settings", () => {
 			coverScale: 0.5,
 			selectedSortByOption: "name",
 			isEnabledDetectionOfGamesByFileChecksum: true,
+			isMergedPlaytimeEnabled: true,
 			isStackedBarsPerGameEnabled: true,
 			pieViewGamesLimit: 50,
 			chartColorSwatch: "DarkMuted",
@@ -102,6 +105,19 @@ describe("Settings", () => {
 		expect(writes).toHaveLength(1);
 	});
 
+	test("migrates version 1 settings with merged playtime disabled", async () => {
+		store({ settingsVersion: 1, showKofiInQAM: 0 });
+
+		const result = await new Settings().get();
+
+		expect(result.settingsVersion).toBe(CURRENT_SETTINGS_VERSION);
+		expect(result.isMergedPlaytimeEnabled).toBe(false);
+		expect(storedObject()).toMatchObject({
+			settingsVersion: CURRENT_SETTINGS_VERSION,
+			isMergedPlaytimeEnabled: 0,
+		});
+	});
+
 	test("replaces every invalid property with its default", async () => {
 		store({
 			settingsVersion: Number.MAX_SAFE_INTEGER,
@@ -111,6 +127,7 @@ describe("Settings", () => {
 			coverScale: "Infinity",
 			selectedSortByOption: "invalid",
 			isEnabledDetectionOfGamesByFileChecksum: "yes",
+			isMergedPlaytimeEnabled: "yes",
 			isStackedBarsPerGameEnabled: 2,
 			pieViewGamesLimit: 17,
 			chartColorSwatch: "Bright",
@@ -197,6 +214,16 @@ describe("Settings", () => {
 			store({ showKofiInQAM: value });
 			expect((await new Settings().get()).showKofiInQAM).toBe(false);
 		}
+
+		for (const value of [true, 1, "1", "true"] as const) {
+			store({ isMergedPlaytimeEnabled: value });
+			expect((await new Settings().get()).isMergedPlaytimeEnabled).toBe(true);
+		}
+
+		for (const value of [false, 0, "0", "false"] as const) {
+			store({ isMergedPlaytimeEnabled: value });
+			expect((await new Settings().get()).isMergedPlaytimeEnabled).toBe(false);
+		}
 	});
 
 	test("accepts cover-scale boundaries and rejects out-of-range values", async () => {
@@ -255,6 +282,7 @@ describe("Settings", () => {
 			displayTime: { showTimeInHours: false, showSeconds: true },
 			coverScale: 1.5,
 			isEnabledDetectionOfGamesByFileChecksum: true,
+			isMergedPlaytimeEnabled: true,
 			isStackedBarsPerGameEnabled: true,
 			showKofiInQAM: false,
 		});
@@ -265,9 +293,44 @@ describe("Settings", () => {
 			coverScale: "1.5",
 			displayTime: { showTimeInHours: 0, showSeconds: 1 },
 			isEnabledDetectionOfGamesByFileChecksum: 1,
+			isMergedPlaytimeEnabled: 1,
 			isStackedBarsPerGameEnabled: 1,
 			showKofiInQAM: 0,
 		});
+	});
+
+	test("exposes the latest merged-playtime setting to synchronous patch callbacks", async () => {
+		const settings = new Settings();
+		await settings.get();
+
+		expect(settings.isMergedPlaytimeEnabled()).toBe(false);
+
+		await settings.save({ ...DEFAULTS, isMergedPlaytimeEnabled: true });
+
+		expect(settings.isMergedPlaytimeEnabled()).toBe(true);
+	});
+
+	test("notifies merged-playtime subscribers only when the setting changes", async () => {
+		const settings = new Settings();
+		const changes: boolean[] = [];
+		const unsubscribe = settings.subscribeMergedPlaytimeEnabled((enabled) => {
+			changes.push(enabled);
+		});
+		await settings.get();
+
+		await settings.save(DEFAULTS);
+		await settings.save({ ...DEFAULTS, isMergedPlaytimeEnabled: true });
+		await settings.save({
+			...DEFAULTS,
+			isMergedPlaytimeEnabled: true,
+			showKofiInQAM: false,
+		});
+
+		expect(changes).toEqual([true]);
+
+		unsubscribe();
+		await settings.save(DEFAULTS);
+		expect(changes).toEqual([true]);
 	});
 
 	test("save normalizes untrusted runtime input", async () => {

--- a/src/test/steamPlayTimePatches.spec.ts
+++ b/src/test/steamPlayTimePatches.spec.ts
@@ -8,6 +8,7 @@ type PlayTimeInformation = Map<
 	{
 		time: number;
 		lastDate: number;
+		isMerged?: boolean;
 	}
 >;
 
@@ -181,6 +182,190 @@ describe("SteamPlayTimePatches", () => {
 		expect(app.minutes_playtime_forever).toBe("10.0");
 		expect(app.minutes_playtime_last_two_weeks).toBe(10);
 		expect(app.rt_last_time_played).toBe(1000);
+	});
+
+	test("native steam overview with isMerged receives the merged values", () => {
+		patches.unMount();
+		patches = new SteamPlayTimePatches(overallCache, twoWeekCache, () => true);
+		patches.mount();
+
+		overallCache.data = new Map([
+			["123", { time: 600, lastDate: 5000, isMerged: true }],
+		]);
+		twoWeekCache.data = new Map([
+			["123", { time: 240, lastDate: 5000, isMerged: true }],
+		]);
+
+		const app = createOverview(123, 1); // Not THIRD_PARTY
+		appStore.m_mapApps.set(123, app);
+
+		expect(app.minutes_playtime_forever).toBe("10.0"); // 600 / 60 = 10.0
+		expect(app.minutes_playtime_last_two_weeks).toBe(4); // 240 / 60 = 4
+		expect(app.rt_last_time_played).toBe(5000);
+	});
+
+	test("disabled merged playtime preserves native steam overview", () => {
+		patches.mount();
+
+		overallCache.data = new Map([
+			["123", { time: 600, lastDate: 5000, isMerged: true }],
+		]);
+		twoWeekCache.data = new Map([
+			["123", { time: 240, lastDate: 5000, isMerged: true }],
+		]);
+
+		const app = createOverview(123, 1);
+		appStore.m_mapApps.set(123, app);
+
+		expect(app.minutes_playtime_forever).toBe("10.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(10);
+		expect(app.rt_last_time_played).toBe(1000);
+	});
+
+	test("setting changes immediately patch and restore loaded native overviews", () => {
+		let enabled = false;
+		const settingSubscribers: Array<(enabled: boolean) => void> = [];
+		patches.unMount();
+		patches = new SteamPlayTimePatches(
+			overallCache,
+			twoWeekCache,
+			() => enabled,
+			(callback) => {
+				settingSubscribers.push(callback);
+				return () => {
+					const index = settingSubscribers.indexOf(callback);
+					if (index !== -1) settingSubscribers.splice(index, 1);
+				};
+			},
+		);
+		patches.mount();
+
+		overallCache.emit(
+			new Map([["123", { time: 600, lastDate: 5000, isMerged: true }]]),
+		);
+		twoWeekCache.emit(
+			new Map([["123", { time: 240, lastDate: 5000, isMerged: true }]]),
+		);
+		const app = createOverview(123, 1);
+		appStore.m_mapApps.set(123, app);
+
+		enabled = true;
+		settingSubscribers[0](true);
+		expect(app.minutes_playtime_forever).toBe("10.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(4);
+		expect(app.rt_last_time_played).toBe(5000);
+
+		overallCache.emit(
+			new Map([["123", { time: 900, lastDate: 6000, isMerged: true }]]),
+		);
+		expect(app.minutes_playtime_forever).toBe("15.0");
+
+		enabled = false;
+		settingSubscribers[0](false);
+		expect(app.minutes_playtime_forever).toBe("10.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(10);
+		expect(app.rt_last_time_played).toBe(1000);
+		expect(settingSubscribers).toHaveLength(1);
+	});
+
+	test("restores native values refreshed by Steam while merging is enabled", () => {
+		let enabled = true;
+		let notifySettingChanged: (enabled: boolean) => void = () => {};
+		patches.unMount();
+		patches = new SteamPlayTimePatches(
+			overallCache,
+			twoWeekCache,
+			() => enabled,
+			(callback) => {
+				notifySettingChanged = callback;
+				return () => {};
+			},
+		);
+		patches.mount();
+
+		overallCache.data = new Map([
+			["123", { time: 600, lastDate: 5000, isMerged: true }],
+		]);
+		twoWeekCache.data = new Map([
+			["123", { time: 240, lastDate: 5000, isMerged: true }],
+		]);
+		const app = createOverview(123, 1, {
+			InitFromProto: () => {
+				app.minutes_playtime_forever = "20.0";
+				app.minutes_playtime_last_two_weeks = 20;
+				app.rt_last_time_locally_played = 2000;
+				app.rt_last_time_played = 2000;
+				app.rt_last_time_played_or_installed = 2000;
+			},
+		});
+		appStore.m_mapApps.set(123, app);
+
+		appInfoStore.OnAppOverviewChange([{ appid: () => 123 }]);
+		app.InitFromProto({});
+		expect(app.rt_last_time_played).toBe(5000);
+
+		enabled = false;
+		notifySettingChanged(false);
+		expect(app.minutes_playtime_forever).toBe("20.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(20);
+		expect(app.rt_last_time_played).toBe(2000);
+	});
+
+	test("restores native values when a cache record stops being merged", () => {
+		patches.unMount();
+		patches = new SteamPlayTimePatches(overallCache, twoWeekCache, () => true);
+		patches.mount();
+
+		const app = createOverview(123, 1);
+		appOverviews.set(123, app);
+		twoWeekCache.emit(
+			new Map([["123", { time: 240, lastDate: 5000, isMerged: true }]]),
+		);
+		overallCache.emit(
+			new Map([["123", { time: 600, lastDate: 5000, isMerged: true }]]),
+		);
+		expect(app.rt_last_time_played).toBe(5000);
+
+		overallCache.emit(
+			new Map([["123", { time: 300, lastDate: 3000, isMerged: false }]]),
+		);
+		expect(app.minutes_playtime_forever).toBe("10.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(10);
+		expect(app.rt_last_time_played).toBe(1000);
+	});
+
+	test("unmount restores native values and unsubscribes from setting changes", () => {
+		const settingSubscribers: Array<(enabled: boolean) => void> = [];
+		patches.unMount();
+		patches = new SteamPlayTimePatches(
+			overallCache,
+			twoWeekCache,
+			() => true,
+			(callback) => {
+				settingSubscribers.push(callback);
+				return () => {
+					settingSubscribers.splice(0);
+				};
+			},
+		);
+		patches.mount();
+
+		overallCache.data = new Map([
+			["123", { time: 600, lastDate: 5000, isMerged: true }],
+		]);
+		twoWeekCache.data = new Map([
+			["123", { time: 240, lastDate: 5000, isMerged: true }],
+		]);
+		const app = createOverview(123, 1);
+		appStore.m_mapApps.set(123, app);
+		expect(app.rt_last_time_played).toBe(5000);
+
+		patches.unMount();
+
+		expect(app.minutes_playtime_forever).toBe("10.0");
+		expect(app.minutes_playtime_last_two_weeks).toBe(10);
+		expect(app.rt_last_time_played).toBe(1000);
+		expect(settingSubscribers).toHaveLength(0);
 	});
 
 	test("subscribes once per cache and unsubscribes on unmount", () => {


### PR DESCRIPTION
## Summary

This adds an opt-in way to show combined playtime from a parent game, its associated games, and aliases directly on the SteamOS game page.

- Adds a disabled-by-default toggle under **Time Management**.
- Includes associated time even when the parent has no native PlayTime record.
- Updates loaded Steam overview and game-detail values immediately when toggled.
- Restores Steam's native values when disabled or when the plugin unloads.
- Keeps existing third-party game behavior unchanged.

Partially addresses #54 by fixing the merged parent-time display on SteamOS. Automatic duplicate detection and destructive database merging remain outside this change.

## Screenshots

### Time Management setting

<img width="1281" height="801" alt="image" src="https://github.com/user-attachments/assets/350f8ede-a4b1-4eb0-bc33-5a3cb4985601" />

### Parent playtime before

<img width="1281" height="801" alt="image" src="https://github.com/user-attachments/assets/1810a6da-b8af-49fd-ba15-36dad141ff47" />

### Parent playtime after
<img width="1281" height="801" alt="image" src="https://github.com/user-attachments/assets/ec23128a-8ff5-49b6-9cb2-4aab9abc6106" />

## Testing

- Verified the toggle on a Steam Deck: `6 minutes -> 13 minutes -> 6 minutes`, without reloading the plugin or Steam UI.
- Frontend: 125 tests passed in three consecutive runs.
- Python: 161 tracked tests passed with ephemeral `uv`.
- Biome, TypeScript, and the production build passed.
